### PR TITLE
Fixed vow promise error

### DIFF
--- a/lib/mongopromise.js
+++ b/lib/mongopromise.js
@@ -9,7 +9,7 @@
 'use strict';
 
 var mongoskin = require('mongoskin'),
-    Promise = require('vow').promise,
+    vow = require('vow'),
     config = require('../.config.json'),
     utils = require('./utils.js');
 
@@ -94,13 +94,13 @@ function patch(method) {
 
         var ctx = this,
             collection = this.collection,
-            promise = Promise(),
+            defer = vow.defer(),
             args = Array.prototype.slice.call(arguments);
 
         // Обработка ошибок
         function callback(err, data) {
             if(err) {
-                promise.reject(err);
+                defer.reject(err);
             } else {
 
                 /**
@@ -108,7 +108,7 @@ function patch(method) {
                  * но для методов-геттеров нужно возвращать еще и результат выполнения,
                  * поэтому фулфилим объект.
                  */
-                promise.fulfill({
+                defer.resolve({
                     collection: ctx,
                     data: data
                 });
@@ -126,7 +126,7 @@ function patch(method) {
         // вызываем нативный метод
         collection[method].apply(collection, args);
 
-        return promise;
+        return defer.promise();
 
     };
 


### PR DESCRIPTION
In some vow version method fulfill was removed.
On vow version `0.4.10` we have error:

```
/Users/seyar/work/mongopromise/lib/mongopromise.js:97
            promise = Promise(),
                      ^
TypeError: undefined is not a function
    at Collection.insert (/Users/seyar/work/mongopromise/lib/mongopromise.js:97:23)
    at Object.<anonymous> (/Users/seyar/work/mongopromise/examples/index.js:6:6)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:935:3
```
